### PR TITLE
[Maintenance] 권한 관련 api 수정

### DIFF
--- a/src/main/java/net/studioxai/studioxBe/domain/auth/service/AuthService.java
+++ b/src/main/java/net/studioxai/studioxBe/domain/auth/service/AuthService.java
@@ -85,7 +85,7 @@ public class AuthService {
 
     @Transactional
     protected void provisioningFolder(User user) {
-        String folderName = user.getUsername() + "의 프로젝트";
+        String folderName = user.getUsername();
         Folder folder = folderService.createRootFolder(folderName, user);
     }
 

--- a/src/main/java/net/studioxai/studioxBe/domain/folder/entity/FolderManager.java
+++ b/src/main/java/net/studioxai/studioxBe/domain/folder/entity/FolderManager.java
@@ -79,6 +79,10 @@ public class FolderManager extends BaseEntity {
         if (permission == Permission.OWNER) {
             throw new FolderManagerExceptionHandler(FolderManagerErrorCode.OWNER_PERMISSION_ASSIGNMENT_FORBIDDEN);
         }
+
+        if (this.permission == Permission.OWNER) {
+            throw new FolderManagerExceptionHandler(FolderManagerErrorCode.OWNER_PERMISSION_CHANGE_FORBIDDEN);
+        }
         this.permission = permission;
     }
 }

--- a/src/main/java/net/studioxai/studioxBe/domain/folder/entity/FolderManager.java
+++ b/src/main/java/net/studioxai/studioxBe/domain/folder/entity/FolderManager.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import net.studioxai.studioxBe.domain.folder.entity.enums.LinkMode;
 import net.studioxai.studioxBe.domain.folder.entity.enums.Permission;
 import net.studioxai.studioxBe.domain.folder.entity.enums.SourceType;
+import net.studioxai.studioxBe.domain.folder.exception.FolderManagerErrorCode;
+import net.studioxai.studioxBe.domain.folder.exception.FolderManagerExceptionHandler;
 import net.studioxai.studioxBe.domain.user.entity.User;
 import net.studioxai.studioxBe.global.entity.BaseEntity;
 
@@ -74,6 +76,9 @@ public class FolderManager extends BaseEntity {
 
 
     public void updateDirectPermission(Permission permission) {
+        if (permission == Permission.OWNER) {
+            throw new FolderManagerExceptionHandler(FolderManagerErrorCode.OWNER_PERMISSION_ASSIGNMENT_FORBIDDEN);
+        }
         this.permission = permission;
     }
 }

--- a/src/main/java/net/studioxai/studioxBe/domain/folder/exception/FolderManagerErrorCode.java
+++ b/src/main/java/net/studioxai/studioxBe/domain/folder/exception/FolderManagerErrorCode.java
@@ -14,6 +14,7 @@ public enum FolderManagerErrorCode implements BaseErrorCode {
     // 403 FORBIDDEN
     USER_NO_FOLDER_AUTHORITY(HttpStatus.FORBIDDEN, "FOLDERMANAGER_403_1", "해당 폴더에 대한 권한이 없습니다."),
     OWNER_PERMISSION_CHANGE_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDERMANAGER_403_2", "해당 프로젝트의 소유주의 권한을 변경할 수 없습니다."),
+    OWNER_PERMISSION_ASSIGNMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDERMANAGER_403_3", "소유주 권한은 부여할 수 없습니다."),
 
     // 404 NOT_FOUND
     FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDERMANAGER_404_1", "해당하는 폴더가 존재하지 않습니다."),

--- a/src/main/java/net/studioxai/studioxBe/domain/folder/service/FolderManagerService.java
+++ b/src/main/java/net/studioxai/studioxBe/domain/folder/service/FolderManagerService.java
@@ -51,6 +51,10 @@ public class FolderManagerService {
 
         PermissionDto myPermission = PermissionDto.create(me.permission());
 
+        folderManagers = folderManagers.stream()
+                .filter(m -> m.permission() != Permission.OWNER)
+                .toList();
+
         return FolderManagersResponse.create(myPermission, folderManagers);
     }
 

--- a/src/test/java/net/studioxai/studioxBe/folder/FolderManagerServiceTest.java
+++ b/src/test/java/net/studioxai/studioxBe/folder/FolderManagerServiceTest.java
@@ -87,7 +87,7 @@ class FolderManagerServiceTest {
     }
 
     @Test
-    @DisplayName("getManagers(userId, folderId): 내 권한 포함해서 응답 생성")
+    @DisplayName("getManagers(userId, folderId): OWNER 권한 제외 해서 응답 생성")
     void getManagersResponse_success() {
         // given
         Long userId = 1L;
@@ -108,8 +108,7 @@ class FolderManagerServiceTest {
         // then
         assertThat(res).isNotNull();
         assertThat(res.myPermission()).isEqualTo(PermissionDto.create(Permission.OWNER));
-        assertThat(res.managers()).hasSize(2);
-        assertThat(res.managers()).extracting(FolderManagerDto::userId).containsExactlyInAnyOrder(userId, 2L);
+        assertThat(res.managers()).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

#58 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

- folder manager list 조회시 OWNER는 조회되지 않도록 수정
- owner로의 권한 변경은 불가하도록 수정
- project provisioning 에서 "의 프로젝트" 워딩 제거

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

getManagers에서 OWNER 제외하고 manager 리턴하도록 수정
<img width="640" height="203" alt="image" src="https://github.com/user-attachments/assets/c1a7dc41-98ef-4525-97eb-ecc8b07d7f84" />


## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요